### PR TITLE
feat: support base cid encodings

### DIFF
--- a/packages/edge-gateway/package.json
+++ b/packages/edge-gateway/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@web3-storage/worker-utils": "^0.3.0-dev",
+    "ipfs-core-utils": "^0.15.0",
     "ipfs-gateway-race": "link:../ipfs-gateway-race",
     "itty-router": "^2.4.5",
     "multiformats": "^9.6.4",
@@ -51,6 +52,9 @@
     "testcontainers": "^8.11.0",
     "typescript": "4.7.3",
     "toml": "^3.0.0"
+  },
+  "peerDependencies": {
+    "undici": "^5.8.0"
   },
   "standard": {
     "ignore": [

--- a/packages/edge-gateway/src/bindings.d.ts
+++ b/packages/edge-gateway/src/bindings.d.ts
@@ -28,7 +28,7 @@ export interface EnvTransformed {
   IPNS_GATEWAY_HOSTNAME: string
   ipfsGateways: Array<string>
   sentry?: Toucan
-  log?: Logging
+  log: Logging
   gwRacer: IpfsGatewayRacer
 }
 

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -1,7 +1,6 @@
 /* global BRANCH, VERSION, COMMITHASH, SENTRY_RELEASE */
 import Toucan from 'toucan-js'
 
-// @ts-ignore needs to be shipped for types
 import { Logging } from '@web3-storage/worker-utils/loki'
 import { createGatewayRacer } from 'ipfs-gateway-race'
 
@@ -35,9 +34,10 @@ export function envAll(request, env, ctx) {
   })
 
   env.log = new Logging(request, ctx, {
+    // @ts-ignore TODO: url should be optional together with token
     url: env.LOKI_URL,
     token: env.LOKI_TOKEN,
-    debug: env.DEBUG,
+    debug: Boolean(env.DEBUG),
     version: env.VERSION,
     commit: env.COMMITHASH,
     branch: env.BRANCH,

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -33,7 +33,7 @@ export async function gatewayGet(request, env, ctx) {
   }
 
   const reqUrl = new URL(request.url)
-  const cid = getCidFromSubdomainUrl(reqUrl)
+  const cid = await getCidFromSubdomainUrl(reqUrl)
   const pathname = reqUrl.pathname
 
   // Validation layer - root CID validation

--- a/packages/edge-gateway/src/index.js
+++ b/packages/edge-gateway/src/index.js
@@ -10,7 +10,7 @@ import { errorHandler } from './error-handler.js'
 import { envAll } from './env.js'
 
 // https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent
-/** @typedef {{ waitUntil(p: Promise<any>): void }} Ctx */
+/** @typedef {ExecutionContext} Ctx */
 
 const router = Router()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 overrides:
   prettier: 2.5.1
@@ -31,6 +31,7 @@ importers:
       esbuild: ^0.14.2
       execa: ^5.1.1
       git-rev-sync: ^3.0.1
+      ipfs-core-utils: ^0.15.0
       ipfs-gateway-race: link:../ipfs-gateway-race
       ipfs-http-client: ^55.0.0
       ipfs-utils: ^9.0.4
@@ -53,6 +54,7 @@ importers:
       uint8arrays: ^3.0.0
     dependencies:
       '@web3-storage/worker-utils': 0.3.0-dev
+      ipfs-core-utils: 0.15.1
       ipfs-gateway-race: link:../ipfs-gateway-race
       itty-router: 2.6.1
       multiformats: 9.7.0
@@ -141,7 +143,6 @@ packages:
         integrity: sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==,
       }
     engines: { node: 4.x || >=6.0.0 }
-    dev: true
 
   /@babel/code-frame/7.18.6:
     resolution:
@@ -272,7 +273,40 @@ packages:
       }
     dependencies:
       multiformats: 9.7.0
-    dev: true
+
+  /@libp2p/interfaces/2.0.4:
+    resolution:
+      {
+        integrity: sha512-MfwkTFyHJtvwNxkjOjzkXyIVvKFtEW2Q3IGRJPyPQMrtB6ll0rGMTlyJ3BQS1bcD0YkNhggFm+8XiU2/0LCBhQ==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      '@multiformats/multiaddr': 10.3.3
+      err-code: 3.0.1
+      interface-datastore: 6.1.1
+      it-pushable: 2.0.2
+      it-stream-types: 1.0.4
+      multiformats: 9.7.0
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
+  /@libp2p/logger/1.1.6:
+    resolution:
+      {
+        integrity: sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      '@libp2p/interfaces': 2.0.4
+      debug: 4.3.4
+      interface-datastore: 6.1.1
+      multiformats: 9.7.0
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
 
   /@miniflare/cache/2.5.1:
     resolution:
@@ -464,6 +498,36 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@multiformats/multiaddr-to-uri/9.0.1:
+    resolution:
+      {
+        integrity: sha512-kSyHZ2lKjoEzHu/TM4ZVwFj4AWV1B9qFBFJjYb/fK1NqrnrNb/M3uhoyckJvP7WZvpDsnEc7fUCpmPipDY6LMw==,
+      }
+    dependencies:
+      '@multiformats/multiaddr': 10.3.3
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
+  /@multiformats/multiaddr/10.3.3:
+    resolution:
+      {
+        integrity: sha512-+LX9RovG7DJsANb+U6VchV/tApcdJzeafbi5+MPUam90oL91BbEh6ozNZOz4Qf5ZEeilexc12oomatmODJh1/w==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      dns-over-http-resolver: 2.1.0
+      err-code: 3.0.1
+      is-ip: 4.0.0
+      multiformats: 9.7.0
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
   /@nodelib/fs.scandir/2.1.5:
     resolution:
       {
@@ -499,28 +563,24 @@ packages:
       {
         integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
       }
-    dev: true
 
   /@protobufjs/base64/1.1.2:
     resolution:
       {
         integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
       }
-    dev: true
 
   /@protobufjs/codegen/2.0.4:
     resolution:
       {
         integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
       }
-    dev: true
 
   /@protobufjs/eventemitter/1.1.0:
     resolution:
       {
         integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
       }
-    dev: true
 
   /@protobufjs/fetch/1.1.0:
     resolution:
@@ -530,42 +590,36 @@ packages:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
-    dev: true
 
   /@protobufjs/float/1.0.2:
     resolution:
       {
         integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
       }
-    dev: true
 
   /@protobufjs/inquire/1.1.0:
     resolution:
       {
         integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
       }
-    dev: true
 
   /@protobufjs/path/1.1.2:
     resolution:
       {
         integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
       }
-    dev: true
 
   /@protobufjs/pool/1.1.0:
     resolution:
       {
         integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
       }
-    dev: true
 
   /@protobufjs/utf8/1.1.0:
     resolution:
       {
         integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
       }
-    dev: true
 
   /@sentry/cli/1.74.4:
     resolution:
@@ -745,21 +799,18 @@ packages:
       {
         integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==,
       }
-    dev: true
 
   /@types/minimatch/3.0.5:
     resolution:
       {
         integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==,
       }
-    dev: true
 
   /@types/node/18.0.1:
     resolution:
       {
         integrity: sha512-CmR8+Tsy95hhwtZBKJBs0/FFq4XX7sDZHlGGf+0q+BRZfMbOTkzkj0AFAuTyXbObDIoanaBBW0+KEW+m3N16Wg==,
       }
-    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution:
@@ -1445,14 +1496,12 @@ packages:
       {
         integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
       }
-    dev: true
 
   /base64-js/1.5.1:
     resolution:
       {
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
-    dev: true
 
   /basic-auth/2.0.1:
     resolution:
@@ -1499,7 +1548,6 @@ packages:
       }
     dependencies:
       browser-readablestream-to-it: 1.0.3
-    dev: true
 
   /blueimp-md5/2.19.0:
     resolution:
@@ -1527,6 +1575,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /boxen/5.1.2:
@@ -1554,7 +1604,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
 
   /brace-expansion/2.0.1:
     resolution:
@@ -1583,6 +1632,9 @@ packages:
     engines: { node: '>=4' }
     dependencies:
       window: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /browser-process-hrtime/1.0.0:
@@ -1597,7 +1649,6 @@ packages:
       {
         integrity: sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==,
       }
-    dev: true
 
   /buffer-crc32/0.2.13:
     resolution:
@@ -1631,7 +1682,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: true
 
   /buildcheck/0.0.3:
     resolution:
@@ -2033,7 +2083,6 @@ packages:
       {
         integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
       }
-    dev: true
 
   /concat-stream/1.6.2:
     resolution:
@@ -2320,6 +2369,11 @@ packages:
       {
         integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
       }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
@@ -2329,6 +2383,11 @@ packages:
       {
         integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
       }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -2346,7 +2405,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /debug/4.3.4_supports-color@9.2.2:
     resolution:
@@ -2506,6 +2564,21 @@ packages:
       - supports-color
     dev: true
 
+  /dns-over-http-resolver/2.1.0:
+    resolution:
+      {
+        integrity: sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      debug: 4.3.4
+      native-fetch: 4.0.2
+      receptacle: 1.3.2
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
   /docker-compose/0.23.17:
     resolution:
       {
@@ -2641,7 +2714,6 @@ packages:
     engines: { node: '>=6' }
     dependencies:
       encoding: 0.1.13
-    dev: true
 
   /emittery/0.8.1:
     resolution:
@@ -2680,7 +2752,6 @@ packages:
       }
     dependencies:
       iconv-lite: 0.6.3
-    dev: true
 
   /end-of-stream/1.4.4:
     resolution:
@@ -2704,7 +2775,6 @@ packages:
       {
         integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==,
       }
-    dev: true
 
   /error-ex/1.3.2:
     resolution:
@@ -3140,7 +3210,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-standard-jsx/11.0.0_73a97fda86477e1388cc6d0864e98ca8:
+  /eslint-config-standard-jsx/11.0.0_ooux7wugi57bhcgmnuegj2mmva:
     resolution:
       {
         integrity: sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==,
@@ -3153,7 +3223,7 @@ packages:
       eslint-plugin-react: 7.30.1_eslint@8.19.0
     dev: true
 
-  /eslint-config-standard/17.0.0_de3ff430bc7027b029d1d7f93e12e66f:
+  /eslint-config-standard/17.0.0_3y77imf4oat3akor274t4exgn4:
     resolution:
       {
         integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==,
@@ -3178,17 +3248,36 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_ulu2225r2ychl26a37c6o2rfje:
     resolution:
       {
         integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==,
       }
     engines: { node: '>=4' }
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-es/4.1.0_eslint@8.19.0:
@@ -3212,7 +3301,11 @@ packages:
       }
     engines: { node: '>=4' }
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
@@ -3220,7 +3313,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.19.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_ulu2225r2ychl26a37c6o2rfje
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -3228,6 +3321,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-n/15.2.4_eslint@8.19.0:
@@ -3509,6 +3606,8 @@ packages:
       debug: 3.2.7
       es6-promise: 4.2.8
       raw-body: 2.5.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /express/4.18.1:
@@ -3549,6 +3648,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /extend/3.0.2:
@@ -3585,7 +3686,6 @@ packages:
       {
         integrity: sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g==,
       }
-    dev: true
 
   /fast-glob/3.2.11:
     resolution:
@@ -3679,6 +3779,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /find-up/2.1.0:
@@ -3891,7 +3993,6 @@ packages:
       {
         integrity: sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==,
       }
-    dev: true
 
   /get-port/5.1.1:
     resolution:
@@ -4257,14 +4358,12 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /ieee754/1.2.1:
     resolution:
       {
         integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
       }
-    dev: true
 
   /ignore-by-default/2.1.0:
     resolution:
@@ -4376,14 +4475,12 @@ packages:
       interface-store: 2.0.2
       nanoid: 3.3.4
       uint8arrays: 3.0.0
-    dev: true
 
   /interface-store/2.0.2:
     resolution:
       {
         integrity: sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==,
       }
-    dev: true
 
   /internal-slot/1.0.3:
     resolution:
@@ -4412,6 +4509,14 @@ packages:
     engines: { node: '>=8' }
     dev: true
 
+  /ip-regex/5.0.0:
+    resolution:
+      {
+        integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dev: false
+
   /ipaddr.js/1.9.1:
     resolution:
       {
@@ -4419,6 +4524,22 @@ packages:
       }
     engines: { node: '>= 0.10' }
     dev: true
+
+  /ipfs-core-types/0.11.1:
+    resolution:
+      {
+        integrity: sha512-K7ZSx9EPEvT4At2kExKyMCqY4Jo3Nb/VnC/iSWqFKRaqb0MTB4IJgvWrwwDuN541tn+dvUnTfOp2wWQSov1UAw==,
+      }
+    dependencies:
+      '@ipld/dag-pb': 2.1.17
+      '@multiformats/multiaddr': 10.3.3
+      interface-datastore: 6.1.1
+      ipfs-unixfs: 6.0.9
+      multiformats: 9.7.0
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
 
   /ipfs-core-types/0.9.0_node-fetch@3.2.6:
     resolution:
@@ -4465,6 +4586,37 @@ packages:
       - supports-color
     dev: true
 
+  /ipfs-core-utils/0.15.1:
+    resolution:
+      {
+        integrity: sha512-nZmUiLctJWMFrEciVkKdDUO2xLpXWy7Ilt0VMJ35Y5+OJznCXxMHUQo1WUALATlo9ziHgDdHFrAUuyW0yB2rww==,
+      }
+    dependencies:
+      '@libp2p/logger': 1.1.6
+      '@multiformats/multiaddr': 10.3.3
+      '@multiformats/multiaddr-to-uri': 9.0.1
+      any-signal: 3.0.1
+      blob-to-it: 1.0.4
+      browser-readablestream-to-it: 1.0.3
+      err-code: 3.0.1
+      ipfs-core-types: 0.11.1
+      ipfs-unixfs: 6.0.9
+      ipfs-utils: 9.0.7
+      it-all: 1.0.6
+      it-map: 1.0.6
+      it-peekable: 1.0.3
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      multiformats: 9.7.0
+      nanoid: 3.3.4
+      parse-duration: 1.0.2
+      timeout-abort-controller: 3.0.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
   /ipfs-http-client/55.0.0_node-fetch@3.2.6:
     resolution:
       {
@@ -4505,7 +4657,6 @@ packages:
     dependencies:
       err-code: 3.0.1
       protobufjs: 6.11.3
-    dev: true
 
   /ipfs-utils/9.0.7:
     resolution:
@@ -4523,11 +4674,10 @@ packages:
       it-to-stream: 1.0.0
       merge-options: 3.0.4
       nanoid: 3.3.4
-      native-fetch: 3.0.0_@achingbrain+node-fetch@2.6.7
+      native-fetch: 3.0.0_hmwa7nplpltavckpkeobtw6pv4
       node-fetch: /@achingbrain/node-fetch/2.6.7
       react-native-fetch-api: 2.0.0
       stream-to-it: 0.2.4
-    dev: true
 
   /ipjs/5.2.0:
     resolution:
@@ -4637,7 +4787,6 @@ packages:
       {
         integrity: sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw==,
       }
-    dev: true
 
   /is-error/2.2.2:
     resolution:
@@ -4728,6 +4877,16 @@ packages:
       ip-regex: 4.3.0
     dev: true
 
+  /is-ip/4.0.0:
+    resolution:
+      {
+        integrity: sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      ip-regex: 5.0.0
+    dev: false
+
   /is-negative-zero/2.0.2:
     resolution:
       {
@@ -4790,7 +4949,6 @@ packages:
         integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==,
       }
     engines: { node: '>=8' }
-    dev: true
 
   /is-plain-object/5.0.0:
     resolution:
@@ -4921,7 +5079,6 @@ packages:
         integrity: sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==,
       }
     engines: { node: '>=12' }
-    dev: true
 
   /isstream/0.1.2:
     resolution:
@@ -4935,7 +5092,6 @@ packages:
       {
         integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==,
       }
-    dev: true
 
   /it-first/1.0.7:
     resolution:
@@ -4952,7 +5108,6 @@ packages:
     dependencies:
       '@types/minimatch': 3.0.5
       minimatch: 3.1.2
-    dev: true
 
   /it-last/1.0.6:
     resolution:
@@ -4966,14 +5121,26 @@ packages:
       {
         integrity: sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==,
       }
-    dev: true
 
   /it-peekable/1.0.3:
     resolution:
       {
         integrity: sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==,
       }
-    dev: true
+
+  /it-pushable/2.0.2:
+    resolution:
+      {
+        integrity: sha512-f/n6HqXGDbHvuMR/3UN+S6W4y/bS1Pxg6Lb0oVc5dbflxy5f3NKkizKs86B8vzqHnB9hm1YpE0pgcEvI3FKDQw==,
+      }
+    dev: false
+
+  /it-stream-types/1.0.4:
+    resolution:
+      {
+        integrity: sha512-0F3CqTIcIHwtnmIgqd03a7sw8BegAmE32N2w7anIGdALea4oAN4ltqPgDMZ7zn4XPLZifXEZlBXSzgg64L1Ebw==,
+      }
+    dev: false
 
   /it-to-stream/1.0.0:
     resolution:
@@ -4987,7 +5154,6 @@ packages:
       p-defer: 3.0.0
       p-fifo: 1.0.0
       readable-stream: 3.6.0
-    dev: true
 
   /itty-router/2.6.1:
     resolution:
@@ -5072,6 +5238,9 @@ packages:
       whatwg-url: 7.1.0
       ws: 6.2.2
       xml-name-validator: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /json-buffer/3.0.0:
@@ -5460,7 +5629,6 @@ packages:
       {
         integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==,
       }
-    dev: true
 
   /loose-envify/1.4.0:
     resolution:
@@ -5589,7 +5757,6 @@ packages:
     engines: { node: '>=10' }
     dependencies:
       is-plain-obj: 2.1.0
-    dev: true
 
   /merge-stream/2.0.0:
     resolution:
@@ -5725,7 +5892,6 @@ packages:
       }
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimatch/5.1.0:
     resolution:
@@ -5782,6 +5948,8 @@ packages:
       depd: 2.0.0
       on-finished: 2.3.0
       on-headers: 1.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /mri/1.2.0:
@@ -5811,14 +5979,12 @@ packages:
       {
         integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==,
       }
-    dev: true
 
   /ms/2.1.3:
     resolution:
       {
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
       }
-    dev: true
 
   /multer/1.4.4:
     resolution:
@@ -5896,7 +6062,6 @@ packages:
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
-    dev: true
 
   /nanoid/4.0.0:
     resolution:
@@ -5918,7 +6083,7 @@ packages:
       abort-controller: 3.0.0
     dev: true
 
-  /native-fetch/3.0.0_@achingbrain+node-fetch@2.6.7:
+  /native-fetch/3.0.0_hmwa7nplpltavckpkeobtw6pv4:
     resolution:
       {
         integrity: sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==,
@@ -5927,7 +6092,6 @@ packages:
       node-fetch: '*'
     dependencies:
       node-fetch: /@achingbrain/node-fetch/2.6.7
-    dev: true
 
   /native-fetch/3.0.0_node-fetch@3.2.6:
     resolution:
@@ -5939,6 +6103,15 @@ packages:
     dependencies:
       node-fetch: 3.2.6
     dev: true
+
+  /native-fetch/4.0.2:
+    resolution:
+      {
+        integrity: sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==,
+      }
+    peerDependencies:
+      undici: '*'
+    dev: false
 
   /natural-compare/1.4.0:
     resolution:
@@ -6319,7 +6492,6 @@ packages:
         integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==,
       }
     engines: { node: '>=8' }
-    dev: true
 
   /p-defer/4.0.0:
     resolution:
@@ -6347,7 +6519,6 @@ packages:
     dependencies:
       fast-fifo: 1.1.0
       p-defer: 3.0.0
-    dev: true
 
   /p-finally/1.0.0:
     resolution:
@@ -6560,7 +6731,6 @@ packages:
       {
         integrity: sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg==,
       }
-    dev: true
 
   /parse-json/4.0.0:
     resolution:
@@ -6875,7 +7045,6 @@ packages:
       '@types/long': 4.0.2
       '@types/node': 18.0.1
       long: 4.0.0
-    dev: true
 
   /proxy-addr/2.0.7:
     resolution:
@@ -7003,7 +7172,6 @@ packages:
       }
     dependencies:
       p-defer: 3.0.0
-    dev: true
 
   /read-pkg/3.0.0:
     resolution:
@@ -7067,7 +7235,6 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    dev: true
 
   /readdir-glob/1.1.2:
     resolution:
@@ -7095,7 +7262,6 @@ packages:
       }
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /rechoir/0.6.2:
     resolution:
@@ -7288,7 +7454,6 @@ packages:
       {
         integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==,
       }
-    dev: true
 
   /retry/0.13.1:
     resolution:
@@ -7392,7 +7557,6 @@ packages:
       {
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
-    dev: true
 
   /saxes/3.1.11:
     resolution:
@@ -7479,6 +7643,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /serialize-error/7.0.1:
@@ -7502,6 +7668,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /set-blocking/2.0.0:
@@ -7671,6 +7839,8 @@ packages:
       morgan: 1.10.0
       multer: 1.4.4
       path-to-regexp: 6.2.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /source-map-support/0.5.21:
@@ -7875,14 +8045,17 @@ packages:
     hasBin: true
     dependencies:
       eslint: 8.19.0
-      eslint-config-standard: 17.0.0_de3ff430bc7027b029d1d7f93e12e66f
-      eslint-config-standard-jsx: 11.0.0_73a97fda86477e1388cc6d0864e98ca8
+      eslint-config-standard: 17.0.0_3y77imf4oat3akor274t4exgn4
+      eslint-config-standard-jsx: 11.0.0_ooux7wugi57bhcgmnuegj2mmva
       eslint-plugin-import: 2.26.0_eslint@8.19.0
       eslint-plugin-n: 15.2.4_eslint@8.19.0
       eslint-plugin-promise: 6.0.0_eslint@8.19.0
       eslint-plugin-react: 7.30.1_eslint@8.19.0
       standard-engine: 15.0.0
     transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
@@ -7909,7 +8082,6 @@ packages:
       }
     dependencies:
       get-iterator: 1.0.2
-    dev: true
 
   /streamsearch/0.1.2:
     resolution:
@@ -8042,7 +8214,6 @@ packages:
       }
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /strip-ansi/3.0.1:
     resolution:
@@ -8263,6 +8434,15 @@ packages:
       native-abort-controller: 1.0.4_abort-controller@3.0.0
       retimer: 3.0.0
     dev: true
+
+  /timeout-abort-controller/3.0.0:
+    resolution:
+      {
+        integrity: sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==,
+      }
+    dependencies:
+      retimer: 3.0.0
+    dev: false
 
   /to-readable-stream/1.0.0:
     resolution:
@@ -8601,7 +8781,6 @@ packages:
       {
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
-    dev: true
 
   /util/0.12.4:
     resolution:
@@ -8655,7 +8834,6 @@ packages:
       {
         integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==,
       }
-    dev: true
 
   /vary/1.1.2:
     resolution:
@@ -8856,6 +9034,9 @@ packages:
     engines: { node: '>=4' }
     dependencies:
       jsdom: 13.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /word-wrap/1.2.3:
@@ -8914,6 +9095,14 @@ packages:
       {
         integrity: sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==,
       }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
     dependencies:
       async-limiter: 1.0.1
     dev: true


### PR DESCRIPTION
This PR adds support for gateway to try to resolve CIDs encoded into more bases than b32 and b58. It includes all the basic bases exported by multiformats module.

`ipfs-core-utils` was added to have a quick way of getting what base decoder we want to try.