### PR TITLE
feat: add cron denylist

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,17 @@
+name: 'Check Conventional Commits'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cron-denylist.yml
+++ b/.github/workflows/cron-denylist.yml
@@ -1,0 +1,37 @@
+name: Cron sync deny list
+
+on:
+  schedule:
+    - cron: '13 0,5,10,15,20 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/edge-gateway/denylist.json'
+
+jobs:
+  update:
+    name: Sync deny list with KV store
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['staging', 'production']
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.32.x
+      - uses: actions/setup-node@v2
+        with:
+          cache: 'pnpm'
+      - run: pnpm install
+      - name: Run job
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_GATEWAY_TOKEN }}
+        run: node packages/edge-gateway/scripts/cli.js denylist sync --env ${{ matrix.env }}
+
+      - name: Heartbeat
+        if: ${{ success() }}
+        run: node packages/edge-gateway/scripts/cli.js heartbeat --token ${{ secrets.OPSGENIE_KEY }} --name cron-edge-gateway-denylist

--- a/packages/edge-gateway/scripts/README.md
+++ b/packages/edge-gateway/scripts/README.md
@@ -1,0 +1,27 @@
+# Gateway CLI
+
+# `denylist add`
+
+Add a CID (or CID + path) to the local deny list. Note: we currently DO NOT support denying by CID + path in the API.
+
+Usage:
+
+```sh
+node scripts/cli.js denylist add <cid> --status 410 --reason bad
+```
+
+Note that `--status` and `--reason` are optional. The default HTTP status is `410` with no reason.
+
+# `denylist sync`
+
+Reads `wrangler.toml` to pick out the correct KV to write to based on the passed `--env` value.
+
+Requires a Cloudflare API token (as an environment variable) in order to write entries.
+
+Usage:
+
+```sh
+CF_API_TOKEN=<token> node scripts/cli.js denylist sync --env production
+```
+
+It reads from the local `denylist.json` as well as the [badbits denylist](https://badbits.dwebops.pub/denylist.json). Sources can be updated in `denylist.js`.

--- a/packages/edge-gateway/scripts/cli.js
+++ b/packages/edge-gateway/scripts/cli.js
@@ -5,6 +5,7 @@ import sade from 'sade'
 import { buildCmd } from './build.js'
 import { ipfsCmd } from './ipfs.js'
 import { denylistSyncCmd, denylistAddCmd } from './denylist.js'
+import { heartbeatCmd } from './heartbeat.js'
 
 const env = process.env.ENV || 'dev'
 const prog = sade('edge-gateway')
@@ -19,6 +20,10 @@ prog
   .option('--start', 'Start docker container', false)
   .option('--stop', 'Stop and clean all dockers artifacts', false)
   .action(ipfsCmd)
+  .command('heartbeat', 'Ping opsgenie heartbeat')
+  .option('--token', 'Opsgenie Token')
+  .option('--name', 'Heartbeat Name')
+  .action(heartbeatCmd)
   .command('denylist sync')
   .describe('Sync the gateway deny list with various sources.')
   .option('--env', 'Wrangler environment to use.', env)

--- a/packages/edge-gateway/scripts/heartbeat.js
+++ b/packages/edge-gateway/scripts/heartbeat.js
@@ -1,0 +1,14 @@
+import { fetch } from '@web-std/fetch'
+
+export async function heartbeatCmd (opts) {
+  try {
+    await fetch(`https://api.opsgenie.com/v2/heartbeats/${opts.name}/ping`, {
+      headers: {
+        Authorization: `GenieKey ${opts.token}`
+      }
+    })
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Adds cron to sync denylist with badbits

It uses same KV as nftstorage.link, so once we get this in we can stop https://github.com/nftstorage/nftstorage.link/actions/workflows/cron-denylist.yml

Needs:
- [x] OpsGenie token secret 
- [ ] OpsGenie event rename

Closes #27 