### PR TITLE
fix: use dag haus cf dedicated gw

### DIFF
--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -32,7 +32,7 @@ routes = [
 kv_namespaces = [{ binding = "DENYLIST", id = "785cf627e913468ca5319523ae929def" }]
 
 [env.production.vars]
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://pinata.nftstorage.link\"]"
+IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.dag.haus\", \"https://pinata.nftstorage.link\"]"
 GATEWAY_HOSTNAME = 'ipfs.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
 DEBUG = "false"
@@ -74,7 +74,7 @@ routes = [
 kv_namespaces = [{ binding = "DENYLIST", id = "f4eb0eca32e14e28b643604a82e00cb3" }]
 
 [env.staging.vars]
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://pinata.nftstorage.link\"]"
+IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.dag.haus\", \"https://pinata.nftstorage.link\"]"
 GATEWAY_HOSTNAME = 'ipfs-staging.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
 DEBUG = "true"


### PR DESCRIPTION
We now have general purpose CF dedicated gateway.

Once merged and released:
- [ ] Firewall to block public access of both CF dedicated gws