### PR TITLE
fix: edge gateway keep status code

### DIFF
--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -301,9 +301,7 @@ function getResponseWithCustomHeaders (
   resolutionLayer,
   resolutionIdentifier
 ) {
-  const clonedResponse = new Response(response.body, {
-    headers: response.headers
-  })
+  const clonedResponse = new Response(response.body, response)
 
   clonedResponse.headers.set('x-dotstorage-resolution-layer', resolutionLayer)
   clonedResponse.headers.set('x-dotstorage-resolution-id', resolutionIdentifier)


### PR DESCRIPTION
We were losing status code on worker binding interaction