### PR TITLE
fix: abort race contestants when all fulfill

### DIFF
--- a/packages/ipfs-gateway-race/lib/index.js
+++ b/packages/ipfs-gateway-race/lib/index.js
@@ -43,7 +43,8 @@ export class IpfsGatewayRacer {
       pathname = '',
       headers = new Headers(),
       noAbortRequestsOnWinner = false,
-      onRaceEnd = nop
+      onRaceEnd = nop,
+      gatewaySignals = {}
     } = {}
   ) {
     const raceWinnerController = new AbortController()
@@ -52,7 +53,10 @@ export class IpfsGatewayRacer {
       gatewayFetch(gwUrl, cid, pathname, {
         headers,
         timeout: this.timeout,
-        signal: raceWinnerController.signal
+        // Combine internal race winner controller signal with custom user signal
+        signal: gatewaySignals[gwUrl]
+          ? anySignal([raceWinnerController.signal, gatewaySignals[gwUrl]])
+          : raceWinnerController.signal
       })
     )
 

--- a/packages/ipfs-gateway-race/test/utils/setup.js
+++ b/packages/ipfs-gateway-race/test/utils/setup.js
@@ -3,7 +3,7 @@ import anyTest from 'ava'
 /**
  * @typedef {import('../../lib').IpfsGatewayRacer} IpfsGatewayRacer
  * @typedef {import('testcontainers').StartedTestContainer} StartedTestContainer
- * @typedef {import('ava').TestInterface<{gwRacer: IpfsGatewayRacer, container: StartedTestContainer}>} TestFn
+ * @typedef {import('ava').TestInterface<{gwRacer: IpfsGatewayRacer, container: StartedTestContainer, gateways: string[]}>} TestFn
  */
 
 export const test = /** @type {TestFn} */ (anyTest)

--- a/packages/ipfs-gateway-race/types.d.ts
+++ b/packages/ipfs-gateway-race/types.d.ts
@@ -7,6 +7,7 @@ export interface IpfsGatewayRaceGetOptions {
   headers?: Headers
   noAbortRequestsOnWinner?: boolean
   onRaceEnd?: (gatewayResponsePromises: GatewayResponsePromise[], winnerResponse: GatewayResponse | undefined) => void
+  gatewaySignals?: Record<string, AbortSignal>
 }
 
 // Gateway Race Responses


### PR DESCRIPTION
This PR updates `ipfs-gateway-race` lib to support an option to abort specific race contestants on demand. When consumers opt in for `noAbortRequestsOnWinner` they can abort when needed.

In `edge-gateway`, we rely on `ipfs-gateway-race` with `noAbortRequestsOnWinner` because we track TTFB of each gateway. However, as soon as fetch promise of gateway requests is fulfilled we can abort the non winner contestants to not get extra bandwidth consumed. 

Closes #11 