### PR TITLE
fix: edge gateway package denylist binding for cron

### DIFF
--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -29,6 +29,9 @@ routes = [
   { pattern = "*.ipns.dag.haus/*", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" },
   { pattern = "*.ipns.dag.haus", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" }
 ]
+kv_namespaces = [
+  { binding = "DENYLIST", id = "785cf627e913468ca5319523ae929def" }
+]
 
 [env.production.vars]
 IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.dag.haus\"]"
@@ -76,6 +79,9 @@ routes = [
   { pattern = "*.ipfs-staging.dag.haus", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" },
   { pattern = "*.ipns-staging.dag.haus/*", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" },
   { pattern = "*.ipns-staging.dag.haus", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" }
+]
+kv_namespaces = [
+  { binding = "DENYLIST", id = "f4eb0eca32e14e28b643604a82e00cb3" }
 ]
 
 [env.staging.vars]


### PR DESCRIPTION
This is still needed for cron until we get denylist in its own package