### PR TITLE
fix: bump google evaluate safe confidence levels

### DIFF
--- a/packages/cid-verifier/test/verification.spec.js
+++ b/packages/cid-verifier/test/verification.spec.js
@@ -129,13 +129,13 @@ test('POST / handles no results', async (t) => {
 test('POST / handles pending results', async (t) => {
   const { mf } = t.context
   const response = await mf.dispatchFetch(`http://localhost:8787/?cid=${pendingCid}&url=${maliciousUrl}`, { method: 'POST' })
-  t.is(await response.text(), 'cid malware detection processed')
+  t.is(await response.text(), 'cid malware detection already processed')
   t.is(response.status, 202)
 })
 
 test('POST / handles overriding existing malware cid', async (t) => {
   const { mf } = t.context
   const response = await mf.dispatchFetch(`http://localhost:8787/?cid=${malwareCid}&url=${maliciousUrl}`, { method: 'POST' })
-  t.is(await response.text(), 'cid malware detection processed')
+  t.is(await response.text(), 'cid malware detection already processed')
   t.is(response.status, 202)
 })

--- a/packages/cid-verifier/wrangler.toml
+++ b/packages/cid-verifier/wrangler.toml
@@ -28,7 +28,7 @@ kv_namespaces = [
 [env.production.vars]
 DEBUG = "false"
 ENV = "production"
-GOOGLE_EVALUATE_SAFE_CONFIDENCE_LEVELS = [ "CONFIDENCE_LEVEL_UNSPECIFIED", "SAFE" ]
+GOOGLE_EVALUATE_SAFE_CONFIDENCE_LEVELS = [ "CONFIDENCE_LEVEL_UNSPECIFIED", "SAFE", "LOW", "MEDIUM" ]
 
 # Staging!
 [env.staging]
@@ -45,7 +45,7 @@ kv_namespaces = [
 [env.staging.vars]
 DEBUG = "true"
 ENV = "staging"
-GOOGLE_EVALUATE_SAFE_CONFIDENCE_LEVELS = [ "CONFIDENCE_LEVEL_UNSPECIFIED", "SAFE" ]
+GOOGLE_EVALUATE_SAFE_CONFIDENCE_LEVELS = [ "CONFIDENCE_LEVEL_UNSPECIFIED", "SAFE", "LOW", "MEDIUM" ]
 
 # Test!
 [env.test]


### PR DESCRIPTION
We had a staging version of web3.storage flagged as malicious LOL 

```
KEY: bafybeibduzzaiid2wuqznu2qhjcnghv7pwovivzmnbanebxnb5jbuoeyue/google-evaluate
VALUE: {"scores":[{"threatType":"SOCIAL_ENGINEERING","confidenceLevel":"SAFE"},{"threatType":"UNWANTED_SOFTWARE","confidenceLevel":"SAFE"},{"threatType":"MALWARE","confidenceLevel":"LOW"}]}
```

https://bafybeibpzakmpdu472pf55xy7ex3m5snu7quxpl3ewk3dl3cw3j5f2a6pq.ipfs-staging.w3[s.]link/ while if we use a public gateway https://bafybeibpzakmpdu472pf55xy7ex3m5snu7quxpl3ewk3dl3cw3j5f2a6pq.ipfs.dweb.link/ we can see it loads and is the web3.storage website.

So, I bumped the levels to ignore until medium and only flag when:

- HIGH | High confidence that the URI given is risky for this threat type.
- VERY_HIGH | Very high confidence that the URI given is risky for this threat type.
- EXTREMELY_HIGH | Extremely high confidence that the URI given is risky for this threat type.

Also just refactored log line to come above to easily combine other results in the future
