### PR TITLE
fix: cid verifier request clone

### DIFF
--- a/packages/cid-verifier/src/index.js
+++ b/packages/cid-verifier/src/index.js
@@ -37,16 +37,18 @@ export default {
    * @param {Ctx} ctx
    */
   async fetch (request, env, ctx) {
+    // Needs request cloned to avoid worker bindings to have request mutated on follow up requests
+    const req = request.clone()
     try {
-      const res = await router.handle(request, env, ctx)
+      const res = await router.handle(req, env, ctx)
       env.log.timeEnd('request')
       return env.log.end(res)
     } catch (/** @type {any} */ error) {
       if (env.log) {
         env.log.timeEnd('request')
-        return env.log.end(serverError(error, request, env))
+        return env.log.end(serverError(error, req, env))
       }
-      return serverError(error, request, env)
+      return serverError(error, req, env)
     }
   }
 }


### PR DESCRIPTION
Experienced issues with references of requests mutating on follow up subrequests to worker binding. This was leading into logs and sentry reports with not correct request url and request method.

Cloning request https://developers.cloudflare.com/workers/runtime-apis/request#instance-methods should fix it. It looked in the logs that it does, but will need to test with actual malware to validate logs with the results correctly

<img width="1928" alt="image" src="https://user-images.githubusercontent.com/7295071/189958520-5ceea9c5-5394-45d4-9131-1074f4e86107.png">
