### PR TITLE
feat: edge gateway with cid verifier behind env var

### DIFF
--- a/packages/edge-gateway/src/bindings.d.ts
+++ b/packages/edge-gateway/src/bindings.d.ts
@@ -17,6 +17,7 @@ export interface AnalyticsEngineEvent {
 export interface EnvInput {
   ENV: string
   DEBUG: string
+  CID_VERIFIER_ENABLED: string
   CID_VERIFIER_URL: string
   CID_VERIFIER: Fetcher
   IPFS_GATEWAYS: string
@@ -46,6 +47,7 @@ export interface EnvTransformed {
   log: Logging
   gwRacer: IpfsGatewayRacer
   startTime: number
+  isCidVerifierEnabled: boolean
 }
 
 export type Env = EnvInput & EnvTransformed

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -34,6 +34,8 @@ export function envAll (request, env, ctx) {
   })
   env.startTime = Date.now()
 
+  env.isCidVerifierEnabled = env.CID_VERIFIER_ENABLED === 'true'
+
   env.log = new Logging(request, ctx, {
     // @ts-ignore TODO: url should be optional together with token
     url: env.LOKI_URL,

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -106,7 +106,10 @@ export async function gatewayGet (request, env, ctx) {
   }
 
   // Ask CID verifier to validate HTML content
-  if (winnerGwResponse && winnerGwResponse.headers.get('content-type')?.includes('text/html')) {
+  if (
+    env.isCidVerifierEnabled &&
+    winnerGwResponse && winnerGwResponse.headers.get('content-type')?.includes('text/html')
+  ) {
     const verifyCid = pathname !== '/' ? resourceCid : cid
     // fire and forget. Let cid-verifier process this cid and url if it needs to
     ctx.waitUntil(

--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -39,6 +39,7 @@ GATEWAY_HOSTNAME = 'ipfs.dag.haus'
 CID_VERIFIER_URL = 'https://cid-verifier.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
 DEBUG = "false"
+CID_VERIFIER_ENABLED = "false"
 ENV = "production"
 
 # TODO: Should point to general API in the future
@@ -90,6 +91,7 @@ GATEWAY_HOSTNAME = 'ipfs-staging.dag.haus'
 CID_VERIFIER_URL = 'https://cid-verifier-staging.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
 DEBUG = "true"
+CID_VERIFIER_ENABLED = "true"
 ENV = "staging"
 
 # TODO: Should point to general API in the future
@@ -130,4 +132,5 @@ GATEWAY_HOSTNAME = 'ipfs.localhost:8787'
 CID_VERIFIER_URL = 'http://cid-verifier.localhost:8787'
 EDGE_GATEWAY_API_URL = 'http://localhost:8787'
 DEBUG = "true"
+CID_VERIFIER_ENABLED = "true"
 ENV = "test"


### PR DESCRIPTION
This PR makes edge-gateway only use cid-verifier if ENV var is set to do so. This is temporary until we wrap up cid-verifier work, so that we are not blocked on releasing edge-gateway as needed.

Production is disabled, Staging and Test are enabled