### PR TITLE
feat: 2 tier race for edge gateway

### DIFF
--- a/packages/edge-gateway/src/bindings.d.ts
+++ b/packages/edge-gateway/src/bindings.d.ts
@@ -20,7 +20,8 @@ export interface EnvInput {
   CID_VERIFIER_ENABLED: string
   CID_VERIFIER_URL: string
   CID_VERIFIER: Fetcher
-  IPFS_GATEWAYS: string
+  IPFS_GATEWAYS_RACE_L1: string
+  IPFS_GATEWAYS_RACE_L2: string
   GATEWAY_HOSTNAME: string
   EDGE_GATEWAY_API_URL: string
   REQUEST_TIMEOUT?: number
@@ -42,10 +43,12 @@ export interface EnvTransformed {
   REQUEST_TIMEOUT: number
   IPFS_GATEWAY_HOSTNAME: string
   IPNS_GATEWAY_HOSTNAME: string
-  ipfsGateways: Array<string>
+  ipfsGatewaysL1: Array<string>
+  ipfsGatewaysL2: Array<string>
   sentry?: Toucan
   log: Logging
-  gwRacer: IpfsGatewayRacer
+  gwRacerL1: IpfsGatewayRacer
+  gwRacerL2: IpfsGatewayRacer
   startTime: number
   isCidVerifierEnabled: boolean
 }

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -28,8 +28,12 @@ export function envAll (request, env, ctx) {
   env.SENTRY_RELEASE = SENTRY_RELEASE
 
   env.sentry = getSentry(request, env, ctx)
-  env.ipfsGateways = JSON.parse(env.IPFS_GATEWAYS)
-  env.gwRacer = createGatewayRacer(env.ipfsGateways, {
+  env.ipfsGatewaysL1 = JSON.parse(env.IPFS_GATEWAYS_RACE_L1)
+  env.ipfsGatewaysL2 = JSON.parse(env.IPFS_GATEWAYS_RACE_L2)
+  env.gwRacerL1 = createGatewayRacer(env.ipfsGatewaysL1, {
+    timeout: env.REQUEST_TIMEOUT
+  })
+  env.gwRacerL2 = createGatewayRacer(env.ipfsGatewaysL2, {
     timeout: env.REQUEST_TIMEOUT
   })
   env.startTime = Date.now()

--- a/packages/edge-gateway/test/cdn.spec.js
+++ b/packages/edge-gateway/test/cdn.spec.js
@@ -126,7 +126,12 @@ test('Get content from cache when existing and only-if-cached cache control is p
 test('Should not get from cache if no-cache cache control header is provided', async (t) => {
   const url =
     'https://bafybeic2hr75ukgwhnasdl3sucxyfedfyp3dijq3oakzx6o24urcs4eige.ipfs.localhost:8787/'
-  const { mf } = t.context
+
+  // Not block on waiting for local daemon only as L1
+  const mf = getMiniflare({
+    IPFS_GATEWAYS_RACE_L1: '["http://localhost:9083"]',
+    IPFS_GATEWAYS_RACE_L2: '["http://localhost:9082"]'
+  })
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), 2000)

--- a/packages/edge-gateway/test/utils/miniflare.js
+++ b/packages/edge-gateway/test/utils/miniflare.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { Miniflare } from 'miniflare'
 
-export function getMiniflare () {
+export function getMiniflare (bindings = {}) {
   let envPath = path.join(process.cwd(), '../../.env')
   if (!fs.statSync(envPath, { throwIfNoEntry: false })) {
     // @ts-ignore
@@ -39,7 +39,8 @@ export function getMiniflare () {
     bindings: {
       PUBLIC_RACE_WINNER: createAnalyticsEngine(),
       PUBLIC_RACE_TTFB: createAnalyticsEngine(),
-      PUBLIC_RACE_STATUS_CODE: createAnalyticsEngine()
+      PUBLIC_RACE_STATUS_CODE: createAnalyticsEngine(),
+      ...bindings
     }
   })
 }

--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -34,7 +34,8 @@ kv_namespaces = [
 ]
 
 [env.production.vars]
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.dag.haus\", \"https://pinata.dag.haus\"]"
+IPFS_GATEWAYS_RACE_L1 = "[\"https://ipfs.io\"]"
+IPFS_GATEWAYS_RACE_L2 = "[\"https://cf.dag.haus\", \"https://w3link.mypinata.cloud\"]"
 GATEWAY_HOSTNAME = 'ipfs.dag.haus'
 CID_VERIFIER_URL = 'https://cid-verifier.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
@@ -86,7 +87,8 @@ kv_namespaces = [
 ]
 
 [env.staging.vars]
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.dag.haus\", \"https://pinata.dag.haus\"]"
+IPFS_GATEWAYS_RACE_L1 = "[\"https://ipfs.io\"]"
+IPFS_GATEWAYS_RACE_L2 = "[\"https://cf.dag.haus\", \"https://w3link.mypinata.cloud\"]"
 GATEWAY_HOSTNAME = 'ipfs-staging.dag.haus'
 CID_VERIFIER_URL = 'https://cid-verifier-staging.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
@@ -127,7 +129,8 @@ name = "PUBLIC_RACE_STATUS_CODE"
 workers_dev = true
 
 [env.test.vars]
-IPFS_GATEWAYS = "[\"http://127.0.0.1:9081\", \"http://localhost:9082\", \"http://localhost:9083\"]"
+IPFS_GATEWAYS_RACE_L1 = "[\"http://127.0.0.1:9081\"]"
+IPFS_GATEWAYS_RACE_L2 = "[\"http://localhost:9082\", \"http://localhost:9083\"]"
 GATEWAY_HOSTNAME = 'ipfs.localhost:8787'
 CID_VERIFIER_URL = 'http://cid-verifier.localhost:8787'
 EDGE_GATEWAY_API_URL = 'http://localhost:8787'


### PR DESCRIPTION
This PR transforms previous gateway race into a two tier race. This is a cost optimisation decision that makes us use ipfs.io first, making other gateways just usable for failure redundancy.

Other details:
- We still keep tier 1 with ipfs.io only for now, but we might add other gateways to tier 1 (for example free cf-ipfs.com).
- Pinata domain changed based on sporadic errors https://user-images.githubusercontent.com/7295071/188930841-8b153be1-2fcf-4447-8a1b-4f377b8c9af4.png that should be handled later on
  - NOTE: This was already added in production on a manual release based on failures on last friday demo

With current work being planned, we will be needing less requests to hit origin servers. Both by enabling [CF Cache Reserve](https://blog.cloudflare.com/introducing-cache-reserve/), and later on start relying on CARs in R2 to fulfil requests.

New design architecture

![reads-pipeline - edge-gateway high level public race Sep 26 (1)](https://user-images.githubusercontent.com/7295071/192287701-b09784b8-f551-4bb6-8f6a-a0011d8306e2.jpg)

