### PR TITLE
fix: cid verifier only logs when malware flagged

### DIFF
--- a/packages/cid-verifier/src/index.js
+++ b/packages/cid-verifier/src/index.js
@@ -43,6 +43,10 @@ export default {
       const res = await router.handle(req, env, ctx)
       return res
     } catch (/** @type {any} */ error) {
+      if (env.log) {
+        env.log.timeEnd('request')
+        return env.log.end(serverError(error, req, env))
+      }
       return serverError(error, req, env)
     }
   }

--- a/packages/cid-verifier/src/index.js
+++ b/packages/cid-verifier/src/index.js
@@ -41,13 +41,8 @@ export default {
     const req = request.clone()
     try {
       const res = await router.handle(req, env, ctx)
-      env.log.timeEnd('request')
-      return env.log.end(res)
+      return res
     } catch (/** @type {any} */ error) {
-      if (env.log) {
-        env.log.timeEnd('request')
-        return env.log.end(serverError(error, req, env))
-      }
       return serverError(error, req, env)
     }
   }

--- a/packages/cid-verifier/src/verification.js
+++ b/packages/cid-verifier/src/verification.js
@@ -95,11 +95,13 @@ export const verificationPost = withRequiredQueryParams(['cid'],
 
     if (!googleEvaluateResult && !googleEvaluateLock) {
       const threats = await fetchGoogleMalwareResults(cid, `https://${cid}.${env.IPFS_GATEWAY_TLD}`, env)
+      const response = new Response('cid malware detection processed', { status: 201 })
 
       if (threats.length) {
         env.log.log(`MALWARE DETECTED for cid "${cid}" ${threats.join(', ')}`, 'info')
+        env.log.end(response)
       }
-      return new Response('cid malware detection processed', { status: 201 })
+      return response
     }
 
     return new Response('cid malware detection already processed', { status: 202 })


### PR DESCRIPTION
Part of https://github.com/web3-storage/reads/issues/84 makes cid-verifier package only log when malware is detected, so that we can act upon it.

cid-verifier package includes denylist routes that will also be dropped after #77 

cc @lanzafame (can't ask you review, sent invitation to join web3-storage org)