### PR TITLE
fix: not abort when no winner

### DIFF
--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -403,15 +403,15 @@ async function reportRaceResults (env, gatewayResponsePromises, winnerUrl, gatew
     })
   )
 
-  // Abort all on going requests except for the winner
-  for (const [gatewayUrl, controller] of Object.entries(gatewayControllers)) {
-    if (winnerUrl !== gatewayUrl) {
-      controller.abort()
-    }
-  }
-
-  // Count winners
   if (winnerUrl) {
+    // Abort all on going requests except for the winner
+    for (const [gatewayUrl, controller] of Object.entries(gatewayControllers)) {
+      if (winnerUrl !== gatewayUrl) {
+        controller.abort()
+      }
+    }
+
+    // Count winners
     env.PUBLIC_RACE_WINNER.writeDataPoint({
       blobs: [winnerUrl],
       doubles: [1]

--- a/packages/edge-gateway/test/index.spec.js
+++ b/packages/edge-gateway/test/index.spec.js
@@ -101,3 +101,16 @@ test('Gets content with other base encodings', async (t) => {
   await response.waitUntil()
   t.is(await response.text(), 'Hello dot.storage! 😎')
 })
+
+test('Gets response error when all fail to resolve', async (t) => {
+  const { mf } = t.context
+
+  const cidStr = 'bafkreibehzafi6gdvlyue5lzxa3rfobvp452kylox6f4vwqpd4xbr54uqu'
+
+  const response = await mf.dispatchFetch(
+    `https://${cidStr}.ipfs.localhost:8787`
+  )
+  await response.waitUntil()
+  const body = await response.text()
+  t.assert(body)
+})

--- a/packages/edge-gateway/test/utils/miniflare.js
+++ b/packages/edge-gateway/test/utils/miniflare.js
@@ -40,6 +40,7 @@ export function getMiniflare (bindings = {}) {
       PUBLIC_RACE_WINNER: createAnalyticsEngine(),
       PUBLIC_RACE_TTFB: createAnalyticsEngine(),
       PUBLIC_RACE_STATUS_CODE: createAnalyticsEngine(),
+      REQUEST_TIMEOUT: 3000,
       ...bindings
     }
   })


### PR DESCRIPTION
If we abort all the requests abort error will be thrown. We should not abort if all failed and there was no winner