### PR TITLE
feat: log anchor

### DIFF
--- a/packages/edge-gateway/src/utils/cid.js
+++ b/packages/edge-gateway/src/utils/cid.js
@@ -1,6 +1,8 @@
 import { Multibases } from 'ipfs-core-utils/multibases'
 import { bases } from 'multiformats/basics'
 import { CID } from 'multiformats/cid'
+import * as uint8arrays from 'uint8arrays'
+import { sha256 } from 'multiformats/hashes/sha2'
 
 import { InvalidUrlError } from '../errors.js'
 
@@ -54,4 +56,15 @@ async function getMultibaseDecoder (cid) {
   const base = await basicBases.getBase(multibasePrefix)
 
   return base.decoder
+}
+
+/**
+ * Get denylist anchor with badbits format.
+ *
+ * @param {string} cid
+ */
+export async function toDenyListAnchor (cid) {
+  const multihash = await sha256.digest(uint8arrays.fromString(`${cid}/`))
+  const digest = multihash.bytes.subarray(2)
+  return uint8arrays.toString(digest, 'hex')
 }

--- a/packages/edge-gateway/test/index.spec.js
+++ b/packages/edge-gateway/test/index.spec.js
@@ -59,6 +59,7 @@ test('Gets content', async (t) => {
 
   // Validate content headers
   t.is(response.headers.get('content-length'), '23')
+  t.is(response.headers.get('x-dotstorage-anchor'), 'd13421337e80609a2aa9412ee646b4f6d6cb088cd9314bca313249896b2d19d0')
 
   // Validate x-dotstorage headers
   t.assert(
@@ -78,6 +79,8 @@ test('Gets content with path', async (t) => {
   // Validate content headers
   t.is(response.headers.get('content-length'), '35')
   t.is(response.headers.get('content-type'), 'text/plain; charset=utf-8')
+  t.is(response.headers.get('x-dotstorage-anchor'), 'fd7c4bfd340f259e1276d8cbd61649ba02b3754fdba044f3bfdefa1bee680fc1')
+
   // Validate x-dotstorage headers
   t.assert(
     response.headers.get('x-dotstorage-resolution-layer')


### PR DESCRIPTION
Once we get Cache Reserve, we will need a way of mapping back an anchor added to badbits/denylist into a URL we want to purge from cache.

Adding anchors to headers (and consequently logs) enables us to quickly search through logs and get the URL to block

Closes #89 