### PR TITLE
fix: end error response should be timeout

### DIFF
--- a/packages/ipfs-gateway-race/lib/index.js
+++ b/packages/ipfs-gateway-race/lib/index.js
@@ -89,20 +89,7 @@ export class IpfsGatewayRacer {
       // Return the error response from gateway, error is not from nft.storage Gateway
       // @ts-ignore FilterError lacks proper types
       if (err instanceof FilterError || err instanceof AggregateError) {
-        const candidateResponse = responses.find((r) => r.value?.response)
-
-        // Return first response with upstream error
-        if (candidateResponse?.value?.response) {
-          return candidateResponse.value.response
-        }
-
-        // Gateway timeout
-        if (
-          responses[0].value?.aborted &&
-          responses[0].value?.reason === TIMEOUT_CODE
-        ) {
-          throw new TimeoutError()
-        }
+        throw new TimeoutError()
       }
 
       throw err


### PR DESCRIPTION
If content is not resolved by any of the caching layers, nor gateway race tiers we should just return a timeout error to the user. Alternatively, we could return a 404 but 404 looks less true representation of the error given we trigger timeouts on each race contestants 