### PR TITLE
fix: dotstorage race requests should receive original request headers

### DIFF
--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -218,7 +218,8 @@ async function getFromDotstorage (request, env, cid, options = {}) {
       }),
       ...env.cdnGateways.map(async (host) => {
         const gwResponse = await gatewayFetch(host, cid, pathname, {
-          timeout: env.REQUEST_TIMEOUT
+          timeout: env.REQUEST_TIMEOUT,
+          headers: request.headers
         })
 
         // @ts-ignore 'response' does not exist on type 'GatewayResponseFailure'


### PR DESCRIPTION
This PR fixes dotstorage race requests to include original request headers. 

This is currently causing problems when range requests happen for content stored within Freeway, as we end up serving the entire content. Example: `curl -v -r 19602680-19668237 "https://bafybeic4ic4gsd45mejopelizyvsq2ybicumtkmqkr6flm6x6kiwbovrc4.ipfs.w3s.link/webarchive.wacz" | wc -c`