### PR TITLE
fix: disable cid verifier in staging

### DIFF
--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -89,7 +89,7 @@ GATEWAY_HOSTNAME = 'ipfs-staging.dag.haus'
 CID_VERIFIER_URL = 'https://cid-verifier-staging.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
 DEBUG = "true"
-CID_VERIFIER_ENABLED = "true"
+CID_VERIFIER_ENABLED = "false"
 ENV = "staging"
 
 # TODO: Should point to general API in the future


### PR DESCRIPTION
We have it disabled in prod. Let's keep it disabled in staging while we don't perform further tests