### PR TITLE
fix: add kv bindings for denylist in edge gateway

### DIFF
--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -30,6 +30,10 @@ routes = [
   { pattern = "*.ipns.dag.haus", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" }
 ]
 
+kv_namespaces = [
+  { binding = "DENYLIST", id = "785cf627e913468ca5319523ae929def" }
+]
+
 [env.production.vars]
 GATEWAY_HOSTNAME = 'ipfs.dag.haus'
 CID_VERIFIER_URL = 'https://cid-verifier.dag.haus'
@@ -83,6 +87,10 @@ routes = [
   { pattern = "*.ipfs-staging.dag.haus", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" },
   { pattern = "*.ipns-staging.dag.haus/*", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" },
   { pattern = "*.ipns-staging.dag.haus", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" }
+]
+
+kv_namespaces = [
+  { binding = "DENYLIST", id = "f4eb0eca32e14e28b643604a82e00cb3" }
 ]
 
 [env.staging.vars]


### PR DESCRIPTION
Because it is required in denylist cron https://github.com/web3-storage/reads/actions/workflows/cron-denylist.yml