### PR TITLE
feat: add different timeout for cdn gateway requests

### DIFF
--- a/packages/edge-gateway/src/bindings.d.ts
+++ b/packages/edge-gateway/src/bindings.d.ts
@@ -30,6 +30,7 @@ export interface EnvInput {
   GATEWAY_HOSTNAME: string
   EDGE_GATEWAY_API_URL: string
   REQUEST_TIMEOUT?: number
+  CDN_REQUEST_TIMEOUT?: number
   SENTRY_DSN?: string
   LOKI_URL?: string
   LOKI_TOKEN?: string

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -23,6 +23,7 @@ import {
  */
 export function envAll (request, env, ctx) {
   env.REQUEST_TIMEOUT = env.REQUEST_TIMEOUT || 20000
+  env.CDN_REQUEST_TIMEOUT = env.CDN_REQUEST_TIMEOUT || 60000
   env.IPFS_GATEWAY_HOSTNAME = env.GATEWAY_HOSTNAME
   env.IPNS_GATEWAY_HOSTNAME = env.GATEWAY_HOSTNAME.replace('ipfs', 'ipns')
 

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -247,7 +247,7 @@ async function getFromDotstorage (request, env, cid, options = {}) {
       }),
       ...env.cdnGateways.map(async (host) => {
         const gwResponse = await gatewayFetch(host, cid, pathname, {
-          timeout: env.REQUEST_TIMEOUT,
+          timeout: env.CDN_REQUEST_TIMEOUT,
           headers: request.headers,
           search
         })


### PR DESCRIPTION
Add different ENV var for timeout for CDN gateways (like freeway) to be independent from race