### PR TITLE
feat: support perma cache fetch disabled via env var

### DIFF
--- a/packages/edge-gateway/src/bindings.d.ts
+++ b/packages/edge-gateway/src/bindings.d.ts
@@ -17,6 +17,7 @@ export interface AnalyticsEngineEvent {
 export interface EnvInput {
   ENV: string
   DEBUG: string
+  PERMA_CACHE_ENABLED: string
   CID_VERIFIER_AUTHORIZATION_TOKEN: string
   CID_VERIFIER_ENABLED: string
   CID_VERIFIER_URL: string
@@ -58,6 +59,7 @@ export interface EnvTransformed {
   gwRacerL2: IpfsGatewayRacer
   startTime: number
   isCidVerifierEnabled: boolean
+  isPermaCacheEnabled: boolean
 }
 
 export type Env = EnvInput & EnvTransformed

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -56,6 +56,7 @@ export function envAll (request, env, ctx) {
   env.startTime = Date.now()
 
   env.isCidVerifierEnabled = env.CID_VERIFIER_ENABLED === 'true'
+  env.isPermaCacheEnabled = env.PERMA_CACHE_ENABLED === 'true'
 
   env.log = new Logging(request, ctx, {
     // @ts-ignore TODO: url should be optional together with token

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -367,6 +367,10 @@ async function getFromCacheZone (request, cache) {
  * @return {Promise<ProxiedCDNResponse | undefined>}
  */
 async function getFromPermaCache (request, env) {
+  if (!env.isPermaCacheEnabled) {
+    return undefined
+  }
+
   const response = await env.API.fetch(
     `${env.EDGE_GATEWAY_API_URL}/perma-cache/${encodeURIComponent(
       request.url

--- a/packages/edge-gateway/test/cdn.spec.js
+++ b/packages/edge-gateway/test/cdn.spec.js
@@ -123,6 +123,23 @@ test('Get content from cache when existing and only-if-cached cache control is p
   )
 })
 
+test('Should not get content from Perma cache if disabled', async (t) => {
+  const mf = getMiniflare({
+    PERMA_CACHE_ENABLED: 'false',
+    IPFS_GATEWAYS_RACE_L1: '[]',
+    IPFS_GATEWAYS_RACE_L2: '[]'
+  })
+
+  // bafybeic2hr75ukgwhnasdl3sucxyfedfyp3dijq3oakzx6o24urcs4eige is in Perma Cache test bucket
+  const url =
+    'https://bafybeic2hr75ukgwhnasdl3sucxyfedfyp3dijq3oakzx6o24urcs4eige.ipfs.localhost:8787/'
+
+  const response = await mf.dispatchFetch(url)
+  await response.waitUntil()
+
+  t.is(response.ok, false)
+})
+
 test('Should not get from cache if no-cache cache control header is provided', async (t) => {
   const url =
     'https://bafybeic2hr75ukgwhnasdl3sucxyfedfyp3dijq3oakzx6o24urcs4eige.ipfs.localhost:8787/'

--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -37,6 +37,7 @@ DENYLIST_URL = 'https://denylist.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
 DEBUG = "false"
 CID_VERIFIER_ENABLED = "false"
+PERMA_CACHE_ENABLED = "false"
 ENV = "production"
 
 # TODO: Should point to general API in the future
@@ -94,6 +95,7 @@ DENYLIST_URL = 'https://denylist-staging.dag.haus'
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
 DEBUG = "true"
 CID_VERIFIER_ENABLED = "false"
+PERMA_CACHE_ENABLED = "false"
 ENV = "staging"
 
 # TODO: Should point to general API in the future
@@ -141,4 +143,5 @@ DENYLIST_URL = 'http://denylist.localhost:8787'
 EDGE_GATEWAY_API_URL = 'http://localhost:8787'
 DEBUG = "true"
 CID_VERIFIER_ENABLED = "true"
+PERMA_CACHE_ENABLED = "true"
 ENV = "test"


### PR DESCRIPTION
Per previous discussion with @dchoi27 , we decided to disable perma cache reads for the time being, in order to reduce the number of worker requests (given there are no active users of this feature).