### PR TITLE
feat: add batch denylist check

### DIFF
--- a/packages/denylist/src/denylist.js
+++ b/packages/denylist/src/denylist.js
@@ -59,7 +59,12 @@ export async function denylistPost (request, env) {
     return new Response('Unsupported Media Type', { status: 415 })
   }
 
-  const checklist = await request.json()
+  let checklist
+  try {
+    checklist = await request.json()
+  } catch (err) {
+    return new Response('Invalid JSON', { status: 400, statusText: 'Bad Request' })
+  }
 
   if (!Array.isArray(checklist)) {
     return new Response('Expected an array', { status: 400, statusText: 'Bad Request' })

--- a/packages/denylist/src/denylist.js
+++ b/packages/denylist/src/denylist.js
@@ -51,12 +51,16 @@ export const denylistGet = async function (request, env) {
 /**
  * Batch denylist check. POST an Array of cid strings.
  * Returns the subset of the Array that are on the deny list.
- * @param {import('itty-router').Request} request
+ * @param {Request} request
  * @param {import('./env').Env} env
  */
 export async function denylistPost (request, env) {
-  if (!request.json) {
-    return new Response('Unsupported Media Type', { status: 415 })
+  const contentType = request.headers.get('Content-Type')
+  if (contentType) {
+    const type = contentType.split(';').at(0)?.trim().toLowerCase()
+    if (type !== 'application/json') {
+      return new Response('Unsupported Media Type', { status: 415 })
+    }
   }
 
   let checklist

--- a/packages/denylist/src/index.js
+++ b/packages/denylist/src/index.js
@@ -2,7 +2,7 @@
 
 import { Router } from 'itty-router'
 
-import { denylistGet } from './denylist.js'
+import { denylistGet, denylistPost } from './denylist.js'
 import { versionGet } from './version.js'
 
 import { addCorsHeaders, withCorsHeaders } from './cors.js'
@@ -19,6 +19,7 @@ router
   .all('*', envAll)
   .get('/version', withCorsHeaders(versionGet))
   .get('/:cid', withCdnCache(withCorsHeaders(denylistGet)))
+  .post('/', withCorsHeaders(denylistPost))
 
 /**
  * @param {Error} error

--- a/packages/denylist/test/denylist.spec.js
+++ b/packages/denylist/test/denylist.spec.js
@@ -103,4 +103,13 @@ test('POST / batch', async t => {
     body: JSON.stringify(tooLong)
   })
   t.is(res.status, 400)
+
+  res = await mf.dispatchFetch('http://localhost:8787/', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(checklist).slice(0, -1)
+  })
+  t.is(res.status, 400)
 })

--- a/packages/denylist/test/denylist.spec.js
+++ b/packages/denylist/test/denylist.spec.js
@@ -107,9 +107,18 @@ test('POST / batch', async t => {
   res = await mf.dispatchFetch('http://localhost:8787/', {
     method: 'POST',
     headers: {
-      'content-type': 'application/json'
+      'content-type': 'application/JSON'
     },
     body: JSON.stringify(checklist).slice(0, -1)
   })
   t.is(res.status, 400)
+
+  res = await mf.dispatchFetch('http://localhost:8787/', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/jsonp'
+    },
+    body: JSON.stringify(checklist)
+  })
+  t.is(res.status, 415, 'should error when content-type not json')
 })


### PR DESCRIPTION
Send an array of CID strings to check if they are on the denylist. Response is the subset of the array that is on the denylist.

```http
POST /
Content-Type: application/json

["cid1","cid2"]
```

This will be used by e-ipfs to check a batch of cids at once, see: https://github.com/elastic-ipfs/bitswap-peer/pull/215

License: MIT