### PR TITLE
feat: batch endpoint check items in parallel

### DIFF
--- a/packages/denylist/wrangler.toml
+++ b/packages/denylist/wrangler.toml
@@ -35,7 +35,7 @@ routes = [
   { pattern = "denylist-staging.dag.haus/*", zone_id = "f2f8a5b1c557202c6e3d0ce0e98e4c8e" }
 ]
 kv_namespaces = [
-  { binding = "DENYLIST", id = "f4eb0eca32e14e28b643604a82e00cb3" }
+  { binding = "DENYLIST", id = "f4eb0eca32e14e28b643604a82e00cb3", preview_id = "f4eb0eca32e14e28b643604a82e00cb3" }
 ]
 
 [env.staging.vars]


### PR DESCRIPTION
Switch to checking all the items in parallel, and let the platform decide the concurrency.

Drops the time to check 1000 items by an order of magnitude
- cold kv from ~180s to ~10s
- warm kv from ~50s to ~5s

```sh
❯ time curl "http://127.0.0.1:8787/" --json @denylist.post.1000.json
[]
________________________________________________________
Executed in    4.36 secs      fish           external
```

...for obvious reason  of not doing each one sequentially.

License: MIT